### PR TITLE
feat: Support configuring how workers are invoked

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ class FileProcessor extends EventEmitter {
     super();
     options = options || {};
     const glob = (this.glob = globStream(globPattern));
+    this.invokeWorker = options.invokeWorker || defaultInvokeWorker;
     const workers = (this.workers = workerFarm(options.worker || {}, worker));
 
     let allQueued = false;
@@ -49,13 +50,17 @@ class FileProcessor extends EventEmitter {
   }
 
   process(path, callback) {
-    this.workers(path, callback);
+    this.invokeWorker(this.workers, path, callback);
   }
 
   destroy(callback) {
     this.glob.destroy();
     workerFarm.end(this.workers, callback);
   }
+}
+
+function defaultInvokeWorker(workers, path, callback) {
+  workers(path, callback);
 }
 
 module.exports = FileProcessor;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -111,4 +111,28 @@ describe('success', () => {
       });
     });
   });
+
+  test('invokeWorker', () => {
+    expect.assertions(3);
+
+    const processor = new FileProcessor(pattern, workerPath, {
+      invokeWorker(workers, filepath, callback) {
+        workers(filepath, (err, result) =>
+          err ? callback(err) : callback(null, `${result}!`)
+        );
+      },
+    });
+
+    const handler = jest.fn();
+    processor.on('processed', handler);
+
+    return new Promise((resolve) => {
+      processor.on('end', () => {
+        expect(handler).toHaveBeenCalledWith(examplePath('1.txt'), 'a!');
+        expect(handler).toHaveBeenCalledWith(examplePath('2.txt'), 'b!');
+        expect(handler).toHaveBeenCalledWith(examplePath('3.txt'), 'c!');
+        resolve();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds an `invokeWorker` option to allow configuring how workers are invoked.

Reason I'm needing this is to provide additional arguments to the worker function, though accepting a wrapper function like this gives us flexibility for other use cases too:

```js
new FileProcessor(pattern, workerPath, {
  invokeWorker(worker, filePath, callback) {
    worker(filePath, arg2, arg3, callback);
  }
});
```